### PR TITLE
Routes should be just imported, not mounted

### DIFF
--- a/MicroKernel.php
+++ b/MicroKernel.php
@@ -39,14 +39,11 @@ class MicroKernel extends Kernel
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
         if (in_array($this->getEnvironment(), array('dev', 'test'), true)) {
-            $routes->mount('/_wdt', $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml'));
-            $routes->mount(
-                '/_profiler',
-                $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')
-            );
+            $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml', '/_wdt');
+            $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml', '/_profiler');
         }
 
-        $routes->mount('/', $routes->import('@AppBundle/Controller', 'annotation'));
+        $routes->import('@AppBundle/Controller', '/', 'annotation');
     }
 
     /*


### PR DESCRIPTION
Routes should be just imported, they don't need to be mounted.

Before (note doubled route prefixes):

```
(master) $ bin/console debug:router
 -------------------------- -------- -------- ------ --------------------------------------------- 
  Name                       Method   Scheme   Host   Path                                         
 -------------------------- -------- -------- ------ --------------------------------------------- 
  _wdt                       ANY      ANY      ANY    /_wdt/_wdt/{token}                           
  _profiler_home             ANY      ANY      ANY    /_profiler/_profiler/                        
  _profiler_search           ANY      ANY      ANY    /_profiler/_profiler/search                  
  _profiler_search_bar       ANY      ANY      ANY    /_profiler/_profiler/search_bar              
...                  
 -------------------------- -------- -------- ------ --------------------------------------------- 
```

After:

```
(import-routes) $ bin/console debug:router
 -------------------------- -------- -------- ------ ----------------------------------- 
  Name                       Method   Scheme   Host   Path                               
 -------------------------- -------- -------- ------ ----------------------------------- 
  _wdt                       ANY      ANY      ANY    /_wdt/{token}                      
  _profiler_home             ANY      ANY      ANY    /_profiler/                        
  _profiler_search           ANY      ANY      ANY    /_profiler/search                  
  _profiler_search_bar       ANY      ANY      ANY    /_profiler/search_bar              
...                       
 -------------------------- -------- -------- ------ -----------------------------------
```

The problem originated from the cookbook I guess: https://github.com/symfony/symfony-docs/pull/6612
